### PR TITLE
URL & YouTube support

### DIFF
--- a/pifmplay/pifmplay
+++ b/pifmplay/pifmplay
@@ -99,10 +99,8 @@ playyoutube() {
 	# TODO: Handle other kind of YouTube URL
 	# than normal "http://youtube.com/watch?v=..."
 
-	printf "Running youtube-dl to fetch video's raw URL, please wait..."
-	rawURLsList="$(youtube-dl -g -f 140 $URL)"
-	printf 'Done!\n'
-	echo "$rawURLsList"|while read rawURL; do # to support playlist
+	echo "Running youtube-dl to fetch video's raw URL, please wait..."
+	youtube-dl -g -f 140 "$URL"|while read rawURL; do # to support playlist
 		playmp3ffmpeg "$rawURL" $2
 	done
 }


### PR DESCRIPTION
I've added support for URL and YouTube support. For basic URL support, I reused the playmp3ffmpeg function to play URL that ffmpeg support. For YouTube support, I used the youtube-dl program to extract raw URL(s) of particular YouTube URL.
